### PR TITLE
Added Toggle Checkbox Functionality to ChatGPT Site Extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ChatGPT Bulk Delete",
-  "version": "1.1",
+  "version": "1.2",
   "description": "A Chrome extension to bulk delete ChatGPT conversations",
   "icons": {
     "48": "icon48.png"

--- a/popup.css
+++ b/popup.css
@@ -49,7 +49,7 @@ body {
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
   }
   
-  button#bulk-delete {
+  button#bulk-delete, button#toggle-checkboxes {
     font-size: 16px;
     background-color: #e74c3c;
     border-color: #c0392b;

--- a/popup.css
+++ b/popup.css
@@ -85,4 +85,9 @@ body {
     background-color: #badb34;
     border-color: #b6b929;
   }
+
+  button#toggle-checkboxes {
+    background-color: #2287da;
+    border-color: #2758ab;
+  }
   

--- a/popup.html
+++ b/popup.html
@@ -15,6 +15,7 @@
             <button id="add-checkboxes"><span>Add</span><br><span>Checkboxes</span></button>
             <button id="remove-checkboxes"><span>Remove</span><br><span>Checkboxes</span></button>                       
         </div>
+        <button id="toggle-checkboxes">Toggle Checkboxes</button>
         <button id="bulk-delete">Bulk delete</button>
     </div>      
     <div class="footer">

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,15 @@ document.getElementById('bulk-delete').addEventListener('click', () => {
   });
 });
 
+document.getElementById('toggle-checkboxes').addEventListener('click', () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['toggleCheckboxes.js']
+    });
+  });
+});
+
 document.getElementById('remove-checkboxes').addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
     chrome.scripting.executeScript({

--- a/toggleCheckboxes.js
+++ b/toggleCheckboxes.js
@@ -1,0 +1,9 @@
+function toggleCheckboxes() {
+  const conversations = document.querySelectorAll(".conversation-checkbox");
+
+  conversations.forEach((checkbox) => {
+    checkbox.checked = !checkbox.checked;
+  });
+}
+
+toggleCheckboxes();


### PR DESCRIPTION
Hello @qcrao,

I would like to contribute an enhancement to the Google Chrome extension for the ChatGPT website. This pull request introduces a new feature called "Toggle Checkbox" that allows users to conveniently select or deselect all chats with a single click.

The `Toggle Checkboxes` functionality brings the following benefits to the extension:

- Improved selection process: Users can easily toggle the checkboxes of all chats at once, facilitating the selection of multiple chats for deletion.
- Streamlined chat management: With a single click, users can select all chats for removal or deselect all chats, making it more efficient to handle a large number of conversations.

I believe this feature will enhance the user experience and provide a more comprehensive solution for chat management within the extension.

Thank you for considering my contribution. I'm open to any feedback or suggestions for further improvements.

Best regards,  
Helton.