### PR TITLE
Fix: Adjusted selector to correctly target conversation items

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -3,14 +3,13 @@ if (typeof window.globalsLoaded === "undefined") {
 
   window.globalsLoaded = true;
 
-  const Selectors = {
-    conversationsCheckbox: ".conversation-checkbox:checked",
-    confirmDeleteButton: "button.btn.btn-danger",
-    threeDotButton: '[id^="radix-"]',
-    CONVERSATION_SELECTOR:
-      "div > div > div > div > div > div > nav > div > div > div > div > ol > li > div > a",
-    TITLE_SELECTOR: ".relative.grow.overflow-hidden.whitespace-nowrap",
-  };
+const Selectors = {
+  conversationsCheckbox: ".conversation-checkbox:checked",
+  confirmDeleteButton: "button.btn.btn-danger",
+  threeDotButton: '[id^="radix-"]',
+  CONVERSATION_SELECTOR: "div.relative > ol > li > div > a",
+  TITLE_SELECTOR: ".relative.grow.overflow-hidden.whitespace-nowrap",
+};
 
   const CHECKBOX_CLASS = "conversation-checkbox";
 


### PR DESCRIPTION
This pull request adjusts the selector used to target chat items in the sidebar. The previous selector did not correctly match the intended elements anymore, resulting in the checkboxes not being added as expected. The updated selector now accurately targets the conversation items, ensuring that the checkboxes are displayed and functional.

## Changes
Updated the CONVERSATION_SELECTOR in global.js to match the correct elements

## Testing
Tested the changes locally to confirm that the checkboxes now appear next to the correct conversation items.