### PR TITLE
fix for delete/archieve of custom gpt chats

### DIFF
--- a/bulkArchiveConversations.js
+++ b/bulkArchiveConversations.js
@@ -50,7 +50,7 @@ async function archiveConversation(checkbox) {
 
   console.log("1. Hovering over conversation...", conversationElement);
 
-  const interactiveElement = conversationElement.querySelector("[draggable]");
+  const interactiveElement = conversationElement.querySelector(Selectors.INTERACTIVE_ELEMENT_SELECTOR);
   if (!interactiveElement) {
     console.log("Skipping conversation - no interactive elements found");
     // Show notification to user

--- a/bulkArchiveConversations.js
+++ b/bulkArchiveConversations.js
@@ -50,7 +50,7 @@ async function archiveConversation(checkbox) {
 
   console.log("1. Hovering over conversation...", conversationElement);
 
-  const interactiveElement = conversationElement.querySelector("[draggable=\"true\"]");
+  const interactiveElement = conversationElement.querySelector("[draggable]");
   if (!interactiveElement) {
     console.log("Skipping conversation - no interactive elements found");
     // Show notification to user

--- a/bulkDeleteConversations.js
+++ b/bulkDeleteConversations.js
@@ -63,7 +63,7 @@ async function deleteConversation(checkbox) {
   console.log("conversationElement", conversationElement);
 
   // Look for interactive element within the conversation element
-  const interactiveElement = conversationElement.querySelector("[draggable]");
+  const interactiveElement = conversationElement.querySelector(Selectors.INTERACTIVE_ELEMENT_SELECTOR);
   if (!interactiveElement) {
     console.log("Skipping conversation - no interactive elements found");
     // Show notification to user

--- a/bulkDeleteConversations.js
+++ b/bulkDeleteConversations.js
@@ -63,7 +63,7 @@ async function deleteConversation(checkbox) {
   console.log("conversationElement", conversationElement);
 
   // Look for interactive element within the conversation element
-  const interactiveElement = conversationElement.querySelector("[draggable=\"true\"]");
+  const interactiveElement = conversationElement.querySelector("[draggable]");
   if (!interactiveElement) {
     console.log("Skipping conversation - no interactive elements found");
     // Show notification to user

--- a/globals.js
+++ b/globals.js
@@ -12,6 +12,7 @@ if (typeof window.globalsLoaded === "undefined") {
     CONVERSATION_SELECTOR: 'li[data-testid^="history-item-"]',
     // 更新标题选择器，保持相对路径
     TITLE_SELECTOR: ".relative.grow.overflow-hidden.whitespace-nowrap",
+    INTERACTIVE_ELEMENT_SELECTOR: '[draggable]',
   };
 
   // Constants

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ChatGPT Bulk Delete",
-  "version": "5.9",
+  "version": "5.10",
   "description": "A Chrome extension to bulk delete ChatGPT conversations",
   "icons": {
     "48": "icon48.png"


### PR DESCRIPTION
Addresses the issue: https://github.com/qcrao/bulk-delete-chatGPT/issues/34

With my last contribution to this extension I broke the possibility to delete the chats created with the custom GPTs.

The reason for that is that custom GPT history items have `draggable="false"`. I've changed the selector to [draggable], so it doesn't matter if it is true or false anymore.