### PR TITLE
feat/refactor: increase the max delay to 60s

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ if (typeof window.configLoaded === "undefined") {
       CHECK_PAYMENT: "/check-payment-status",
       PAY_BULK_ARCHIVE: "/pay-bulk-archive"
     },
-    TIMEOUT: 10000
+    TIMEOUT: 60000
   };
 
   // UI Configuration
@@ -30,7 +30,7 @@ if (typeof window.configLoaded === "undefined") {
       BATCH_SIZE: 10,
       DEFAULT_BASE_DELAY_MS: 1200,
       MIN_BASE_DELAY_MS: 300,
-      MAX_BASE_DELAY_MS: 10000,
+      MAX_BASE_DELAY_MS: 60000,
       DEFAULT_AUTO_SLOWDOWN: true,
       INTRA_BATCH_GROWTH: 0.25,
       BATCH_COOLDOWN_BASE_MULTIPLIER: 3,

--- a/popup.html
+++ b/popup.html
@@ -59,7 +59,7 @@
               id="operationDelayInput"
               type="number"
               min="300"
-              max="10000"
+              max="60000"
               step="100"
             />
             <span>ms</span>

--- a/popup.js
+++ b/popup.js
@@ -15,7 +15,7 @@ const DELAY_SETTINGS_CONFIG = {
     autoSlowdown: true
   },
   minBaseDelayMs: 300,
-  maxBaseDelayMs: 10000,
+  maxBaseDelayMs: 60000,
   batchSize: 10
 };
 


### PR DESCRIPTION
This PR increases the maximum configurable delay between conversation operations (such as bulk delete and archive) from 10 seconds (10,000ms) to 60 seconds (60,000ms), addressing #58.

## Changes Made
- **`config.js`**: Updated the core `MAX_BASE_DELAY_MS` and generic `TIMEOUT` variables from 10,000 to 60,000.
-  **`popup.html`**: Raised the `max` attribute on the settings number input field (`#operationDelayInput`) to `60000`.
- **`popup.js`**: Synced the local `DELAY_SETTINGS_CONFIG.maxBaseDelayMs` property to `60000` to ensure the settings sanitizer allows the new maximum value to be saved properly.

## Testing
- Load the extension locally.
-  Open the settings panel in the extension popup.
-  Verify that a delay of up to `60000` ms can now be entered and successfully saved without being automatically reverted to `10000`.